### PR TITLE
Fix: wrong submodule URL.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "engine"]
 	path = collector/core
-	url = https://ariel@dev.arielvb.com/git/pfcengine.git
+	url = ../collector.core.git


### PR DESCRIPTION
Use GitHub URL for collector.core submodule instead of old private git repository.